### PR TITLE
feat: Adapt Jira on Cloud Run solution for MySQL

### DIFF
--- a/CLOUD_RUN_DEPLOYMENT.md
+++ b/CLOUD_RUN_DEPLOYMENT.md
@@ -1,0 +1,174 @@
+# Deploying Custom Jira to Cloud Run
+
+## 1. Introduction
+
+This document guides you through building your custom Jira Docker image (created using the `Dockerfile` in this repository), pushing it to a Google Cloud container registry (GCR or Artifact Registry), and deploying it as a service on Cloud Run.
+
+### Prerequisites
+
+Before proceeding, ensure you have completed the following:
+
+*   **Cloud SQL for MySQL Setup:** Your MySQL instance should be ready, and you should have the database name, username, and password. Refer to `CLOUD_SQL_SETUP.md`.
+*   **Google Cloud Storage (GCS) Bucket Setup:** A GCS bucket for Jira attachments must be created and accessible by your Jira service account. Refer to `GCS_BUCKET_SETUP.md`.
+*   **Docker:** Docker must be installed and running on your local machine to build the image.
+*   **Google Cloud SDK (`gcloud` CLI):** The `gcloud` command-line tool must be installed and authenticated. If not, install it from [here](https://cloud.google.com/sdk/docs/install) and run `gcloud auth login`.
+*   **Project Configuration:** Ensure your `gcloud` CLI is configured for the correct project: `gcloud config set project YOUR_PROJECT_ID`.
+
+**Important:** Replace all placeholders like `YOUR_PROJECT_ID`, `YOUR_REGION`, `YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME`, etc., with your actual values.
+
+## 2. Building the Docker Image
+
+Navigate to the directory containing your `Dockerfile` and the `startup_scripts` directory.
+
+Run the following command to build your Docker image:
+
+**Option 1: Using Google Container Registry (GCR)**
+
+```bash
+docker build -t gcr.io/YOUR_PROJECT_ID/jira-cloudrun:latest .
+```
+Replace `YOUR_PROJECT_ID` with your Google Cloud Project ID.
+
+**Option 2: Using Google Artifact Registry**
+
+Artifact Registry is Google Cloud's recommended service for storing and managing container images.
+
+First, ensure you have an Artifact Registry Docker repository created in your project. If not, create one (e.g., `jira-repo` in `YOUR_REGION`):
+```bash
+gcloud artifacts repositories create jira-repo \
+    --repository-format=docker \
+    --location=YOUR_REGION \
+    --description="Jira Docker repository"
+```
+Replace `YOUR_REGION` with your desired region (e.g., `us-central1`).
+
+Then, build and tag your image:
+```bash
+docker build -t YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/jira-repo/jira-cloudrun:latest .
+```
+Replace `YOUR_REGION`, `YOUR_PROJECT_ID`, and `jira-repo` (if you used a different name) with your actual values.
+
+## 3. Pushing the Docker Image
+
+After successfully building the image, you need to push it to the chosen registry.
+
+**Option 1: Pushing to Google Container Registry (GCR)**
+
+1.  **Configure Docker for GCR:**
+    If you haven't pushed images to GCR from your machine before, you might need to configure Docker credentials:
+    ```bash
+    gcloud auth configure-docker
+    ```
+    This command configures Docker to use your `gcloud` credentials to authenticate with GCR.
+
+2.  **Push the image:**
+    ```bash
+    docker push gcr.io/YOUR_PROJECT_ID/jira-cloudrun:latest
+    ```
+
+**Option 2: Pushing to Google Artifact Registry**
+
+1.  **Configure Docker for Artifact Registry:**
+    If you haven't pushed images to Artifact Registry from your machine before, configure Docker credentials for your specific region:
+    ```bash
+    gcloud auth configure-docker YOUR_REGION-docker.pkg.dev
+    ```
+    Replace `YOUR_REGION` with the region where your Artifact Registry repository is located.
+
+2.  **Push the image:**
+    ```bash
+    docker push YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/jira-repo/jira-cloudrun:latest
+    ```
+
+## 4. Deploying to Cloud Run via `gcloud`
+
+Use the `gcloud run deploy` command to deploy your Jira application.
+
+**Command Structure:**
+
+```bash
+gcloud run deploy jira-service \
+    --image YOUR_IMAGE_URL \
+    --platform managed \
+    --region YOUR_REGION \
+    --project YOUR_PROJECT_ID \
+    --set-env-vars="DB_HOST=127.0.0.1,DB_PORT=3306,DB_NAME=YOUR_DB_NAME,DB_USER=YOUR_DB_USER,DB_PASSWORD=YOUR_DB_PASSWORD,GCS_BUCKET_NAME=YOUR_GCS_BUCKET_NAME,JIRA_LICENSE_KEY=YOUR_JIRA_LICENSE_KEY" \
+    --add-cloudsql-instances=YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME \
+    --memory=8Gi \
+    --cpu=2 \
+    --service-account=YOUR_SERVICE_ACCOUNT_EMAIL \
+    --timeout=900s \
+    --max-instances=1 \
+    --allow-unauthenticated # Consider security implications
+```
+
+**Replace the following placeholders:**
+
+*   `jira-service`: Choose a name for your Cloud Run service.
+*   `YOUR_IMAGE_URL`:
+    *   For GCR: `gcr.io/YOUR_PROJECT_ID/jira-cloudrun:latest`
+    *   For Artifact Registry: `YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/jira-repo/jira-cloudrun:latest`
+*   `YOUR_REGION`: The region where you want to deploy your Cloud Run service (e.g., `us-central1`). **This should ideally be the same region as your Cloud SQL instance and GCS bucket.**
+*   `YOUR_PROJECT_ID`: Your Google Cloud Project ID.
+*   `YOUR_DB_NAME`: The name of your Jira database (e.g., `jiradb`).
+*   `YOUR_DB_USER`: The username for your Jira database (e.g., `jiradbuser`).
+*   `DB_PORT`: The port number for your MySQL database (e.g., `3306`). If not set, the entrypoint script defaults to `3306`.
+*   `YOUR_DB_PASSWORD`: The password for your Jira database user. **Consider using Secret Manager for sensitive values like passwords:**
+    *   Store the password in Secret Manager: `gcloud secrets versions add DB_PASSWORD_SECRET --data-file="/path/to/password.txt"`
+    *   Then, in `--set-env-vars`, use: `DB_PASSWORD=latest:DB_PASSWORD_SECRET`
+*   `YOUR_GCS_BUCKET_NAME`: The name of your GCS bucket for attachments.
+*   `YOUR_JIRA_LICENSE_KEY`: Your Jira Software license key.
+*   `YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME`: The connection name of your Cloud SQL for MySQL instance (e.g., `YOUR_PROJECT_ID:YOUR_REGION:YOUR_SQL_INSTANCE_ID`). This is found on the Cloud SQL instance's overview page. **Using this method is highly recommended as it automatically configures the Cloud SQL Proxy sidecar container.**
+*   `YOUR_SERVICE_ACCOUNT_EMAIL`: The email of the service account that Cloud Run will use. This service account needs "Storage Object Admin" on the GCS bucket and typically "Cloud SQL Client" to connect to the database (though `--add-cloudsql-instances` often handles this). If you created a dedicated service account for Jira, use that. Otherwise, you might use the default Compute Engine service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`).
+
+**Explanation of Parameters:**
+
+*   `--set-env-vars`: Sets the environment variables required by your `custom_entrypoint.sh` script.
+    *   `DB_HOST=127.0.0.1`: When using `--add-cloudsql-instances`, the Cloud SQL Proxy runs as a sidecar, and Jira connects to it via localhost.
+    *   `DB_PORT=3306`: (Example in the main command, also default in entrypoint) Set this if your MySQL instance uses a non-default port.
+    *   Optional Jira proxy variables (if Jira is behind a reverse proxy and needs to know its public URL):
+        *   `JIRA_PROXY_NAME=your-jira-domain.com`
+        *   `JIRA_PROXY_PORT=443`
+        *   `JIRA_SCHEME=https`
+*   `--add-cloudsql-instances`: Connects your Cloud Run service to your Cloud SQL for MySQL instance securely. The Cloud SQL Proxy is automatically configured.
+*   `--memory`: Amount of memory allocated to the instance (e.g., `8Gi`). Jira is memory-intensive.
+*   `--cpu`: Number of vCPUs allocated (e.g., `2`).
+*   `--service-account`: Specifies the IAM service account for the Cloud Run service.
+*   `--timeout`: Maximum request processing time (e.g., `900s`). Jira operations can sometimes be lengthy.
+*   `--max-instances=1`: **Crucial for non-clustered Jira Data Center.** Standard Jira Software or Jira Data Center without clustering support should run as a single instance to avoid data corruption with the `JIRA_HOME` directory.
+*   `--allow-unauthenticated`: Allows public access to your Jira instance. If you want to restrict access (e.g., via IAP or internal load balancer), remove this and configure appropriate authentication methods.
+
+## 5. Considerations for `JIRA_HOME`
+
+The `JIRA_HOME` directory (`/var/atlassian/application-data/jira`) stores various Jira data, including plugins, indexes, caches, and attachments.
+
+*   **Attachments:** In this setup, attachments are offloaded to Google Cloud Storage (GCS) via the `custom_entrypoint.sh` script, ensuring persistent and scalable storage for them.
+*   **Other `JIRA_HOME` Data (Indexes, Caches, Plugins):**
+    *   By default, the rest of the `JIRA_HOME` data (indexes, caches, installed plugins, logos, etc.) will use the Cloud Run container's ephemeral filesystem. This means if the instance is restarted or moved, this data might be lost, leading to re-indexing or re-configuration needs.
+    *   **For optimal performance and data persistence for these components**, especially for production environments, you would ideally mount a persistent disk solution for `JIRA_HOME`.
+        *   Google Cloud Filestore (NFS) is a possible solution and has beta support for Cloud Run. This involves setting up a Filestore instance and a Serverless VPC Access connector.
+        *   This advanced setup is not covered in these primary deployment steps due to its complexity but is a key consideration for production workloads requiring high availability and performance.
+    *   For now, be aware that frequent instance restarts might lead to longer startup times as caches are rebuilt or plugins reinstalled (if not baked into the image).
+    *   The database connection details (e.g., `DB_NAME`, `DB_USER`) should match what you configured when setting up your Cloud SQL for MySQL instance.
+
+## 6. Post-Deployment
+
+1.  **Access Jira:** Once the deployment is complete, `gcloud` will output the URL for your Jira service. Open this URL in your browser.
+2.  **Jira Setup Wizard:** You should be greeted by the Jira setup wizard.
+    *   Choose "I'll set it up myself."
+    *   Configure the database: The `dbconfig.xml` should have been created by the entrypoint script. If prompted, the details are what you provided in the environment variables.
+    *   Follow the on-screen instructions to complete the setup, including providing your license key (if not pre-set via `JIRA_LICENSE_KEY` and already active).
+3.  **Test Attachments:** Create an issue and try uploading and downloading an attachment to verify the GCS integration is working. Check your GCS bucket to see if the attachment appears.
+
+## 7. Updating the Service
+
+To update your Jira service (e.g., with a new image version containing Jira updates or script changes):
+
+1.  Build and push your new Docker image (as described in Sections 2 and 3).
+2.  Re-run the `gcloud run deploy` command from Section 4, ensuring the `--image` parameter points to your new image tag. Cloud Run will perform a rolling update.
+
+```bash
+gcloud run deploy jira-service --image YOUR_NEW_IMAGE_URL --region YOUR_REGION --project YOUR_PROJECT_ID # ... (include other relevant parameters from your initial deploy)
+```
+
+Remember to keep your environment variables and other configurations consistent unless intentionally changing them.

--- a/CLOUD_SQL_SETUP.md
+++ b/CLOUD_SQL_SETUP.md
@@ -1,0 +1,110 @@
+# Setting up MySQL on Google Cloud SQL for Jira
+
+## 1. Introduction
+
+This document provides a step-by-step guide to setting up a MySQL database instance on Google Cloud SQL, specifically configured for use with a Jira deployment. Following these instructions will ensure your Jira instance has a robust and scalable database backend.
+
+## 2. Prerequisites
+
+Before you begin, ensure you have the following:
+
+*   **A Google Cloud Project:** You need an active Google Cloud Project where you have permissions to create and manage Cloud SQL instances.
+*   **`gcloud` CLI installed and configured (Optional):** The Google Cloud Command Line Interface (`gcloud`) can be used for some operations, particularly connecting to the instance. However, most steps can be performed via the Google Cloud Console. If you plan to use `gcloud`, ensure it's [installed](https://cloud.google.com/sdk/docs/install) and [initialized](https://cloud.google.com/sdk/docs/initializing).
+
+## 3. Creating the Cloud SQL Instance
+
+Follow these steps to create your PostgreSQL instance using the Google Cloud Console:
+
+1.  **Navigate to Cloud SQL:** In the Google Cloud Console, use the navigation menu to go to "SQL" (under Storage or Databases).
+2.  **Create Instance:** Click the "Create Instance" button.
+3.  **Choose MySQL:** Select "Choose MySQL" as your database engine.
+4.  **Instance ID:** Enter a unique "Instance ID" for your database (e.g., `jira-mysql-instance`). This will be part of its connection name.
+5.  **Password:** Set a strong root password for the `root` user (e.g., `root@%`). Store this securely, though we will create a separate user for Jira later.
+6.  **Region:** Choose a "Region" for your instance. **It is highly recommended to select the same region where your Jira application (e.g., running on Cloud Run or GKE) will be deployed** to minimize latency.
+7.  **Database version:** Select a MySQL version. Jira typically supports recent versions. **MySQL 8.0 is recommended.**
+8.  **Presets:** For "Presets," you can choose "Development" for testing or "Production" for live environments. This will influence default settings like machine type and HA.
+9.  **Machine Type:**
+    *   Select an appropriate "Machine type." For initial setups or smaller Jira instances, `db-custom-1-3840` (1 vCPU, 3.75 GB RAM) or `db-n1-standard-1` can be a good starting point.
+    *   For production environments, monitor Jira's performance and adjust the machine type as needed.
+10. **Storage:**
+    *   **Storage type:** Choose "SSD" for optimal performance.
+    *   **Storage capacity:** Start with a reasonable initial size (e.g., 20 GB or 50 GB).
+    *   **Enable automatic storage increases:** Check this box to allow the storage to grow automatically as needed, preventing downtime due to full disks.
+11. **Connectivity:** This is a crucial step.
+    *   **Public IP vs. Private IP:**
+        *   **Public IP:** Assigns a publicly accessible IP address to your instance. Access is controlled via "Authorized Networks." This is simpler for initial setup but less secure if not properly restricted.
+        *   **Private IP:** Assigns an IP address within a Virtual Private Cloud (VPC) network in your project. This is more secure as the database is not exposed to the public internet. It typically requires your Jira application to be within the same VPC or connected via a Serverless VPC Access connector (if Jira is on Cloud Run).
+    *   **Configuring Authorized Networks (if using Public IP):**
+        *   Under "Connectivity," if you've chosen "Public IP," expand the "Networking" section.
+        *   Click "Add a network."
+        *   To allow access from any IP address for initial testing (e.g., connecting from your local machine with `mysql` or Cloud Shell), you can enter `0.0.0.0/0`. **WARNING: This is insecure for production environments. Replace this with the specific IP addresses or ranges of your Jira application servers or your own static IP once testing is complete.**
+        *   If your Jira application will run on services like Cloud Run, you might need to find its egress IP addresses or use a Private IP setup.
+    *   **Private IP and Serverless VPC Access:**
+        *   If you choose "Private IP," you'll need to select a VPC network.
+        *   For services like Cloud Run to connect to a Private IP Cloud SQL instance, you'll need to set up a [Serverless VPC Access connector](https://cloud.google.com/vpc/docs/serverless-vpc-access).
+12. **Backups:**
+    *   Under the "Data Protection" section (or "Backups" depending on the console version), **ensure "Enable automated backups" is checked.**
+    *   Configure a backup window that suits your operational needs. Point-in-time recovery (PITR) is also highly recommended and enabled by default if you enable automated backups.
+13. **Create Instance:** Review your settings and click "Create Instance." Provisioning can take several minutes.
+
+## 4. Creating the Jira Database
+
+Once your Cloud SQL instance is running, you need to create a dedicated database for Jira.
+
+1.  **Connect to the Instance:**
+    *   **Using Cloud Shell (`gcloud`):**
+        1.  Open Cloud Shell from the Google Cloud Console.
+        2.  Get your instance connection name from the Cloud SQL instance overview page (e.g., `your-project-id:your-region:your-instance-id`).
+        3.  Run: `gcloud sql connect your-instance-id --user=root --project=your-project-id`
+        4.  Enter the `root` user password you set during instance creation.
+    *   **Using a local `mysql` client (if Public IP is configured and your IP is authorized):**
+        1.  Get the Public IP address of your Cloud SQL instance from its overview page.
+        2.  Run: `mysql --host=INSTANCE_PUBLIC_IP --user=root --password`
+        3.  Enter the `root` user password when prompted.
+        *Note: For production, always ensure SSL is properly configured for connections.*
+
+2.  **SQL Command to Create Database:**
+    Execute the following SQL command in the `mysql` prompt:
+
+    ```sql
+    CREATE DATABASE jiradb CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+    ```
+    This command creates a database named `jiradb` with the recommended character set and collation settings for Jira with MySQL.
+
+## 5. Creating the Jira Database User
+
+Next, create a dedicated user for Jira to access this database.
+
+1.  **SQL Command to Create User:**
+    While still connected to your instance via `mysql` (as the `root` user), execute:
+
+    ```sql
+    CREATE USER 'jiradbuser'@'%' IDENTIFIED BY 'your-secure-password-here';
+    ```
+    **Important:** Replace `'your-secure-password-here'` with a strong, unique password. Store this password securely as it will be needed for your Jira configuration.
+
+2.  **SQL Command to Grant Privileges:**
+    Grant the new user full privileges on the `jiradb` database:
+
+    ```sql
+    GRANT ALL PRIVILEGES ON jiradb.* TO 'jiradbuser'@'%';
+    FLUSH PRIVILEGES;
+    ```
+
+3.  **Exit `mysql`:** You can type `exit` or `\q` to exit the `mysql` prompt.
+
+## 6. Required Connection Information
+
+Once the above steps are completed, you will have the following information needed to configure Jira to connect to this database:
+
+*   **`DB_HOST`**:
+    *   If using **Public IP**: This is the "Public IP address" shown on your Cloud SQL instance's overview page.
+    *   If using **Private IP** with the **Cloud SQL Proxy**: This will be `127.0.0.1` (as the proxy runs locally).
+    *   If using **Private IP** directly from within the same VPC: This is the "Private IP address" of the instance.
+*   **`DB_PORT`**: `3306` (the default MySQL port).
+*   **`DB_NAME`**: `jiradb` (or the name you chose in step 4).
+*   **`DB_USER`**: `jiradbuser` (or the username you chose in step 5).
+*   **`DB_PASSWORD`**: The secure password you set for `jiradbuser` in step 5.
+*   **`CLOUD_SQL_INSTANCE_CONNECTION_NAME`**: (Primarily for Cloud SQL Proxy when using `gcloud run deploy`) This is found on the Cloud SQL instance's overview page in the format `your-project-id:your-region:your-instance-id`. The Cloud Run deployment uses this to automatically configure the Cloud SQL Auth Proxy.
+
+Keep this information readily available for when you deploy and configure your Jira application.

--- a/GCS_BUCKET_SETUP.md
+++ b/GCS_BUCKET_SETUP.md
@@ -1,0 +1,61 @@
+# Setting up Google Cloud Storage (GCS) for Jira Attachments
+
+## 1. Introduction
+
+This guide provides instructions on how to set up a Google Cloud Storage (GCS) bucket. This bucket will be used by your Jira instance to store and manage file attachments associated with Jira issues, providing a scalable and durable storage solution.
+
+## 2. Prerequisites
+
+Before you begin, ensure you have the following:
+
+*   **A Google Cloud Project:** You need an active Google Cloud Project where you have permissions to create and manage GCS buckets and IAM policies.
+
+## 3. Creating the GCS Bucket
+
+Follow these steps to create your GCS bucket using the Google Cloud Console:
+
+1.  **Navigate to Cloud Storage:** In the Google Cloud Console, use the navigation menu to go to "Cloud Storage" > "Buckets."
+2.  **Create Bucket:** Click the "Create bucket" button.
+3.  **Name your bucket:**
+    *   Enter a **globally unique name** for your bucket (e.g., `your-company-jira-attachments`). GCS bucket names must be unique across all of Google Cloud.
+    *   Note this name down, as it will be needed for Jira configuration (`GCS_BUCKET_NAME`).
+4.  **Choose where to store your data (Location type and Location):**
+    *   **Location type:** Select "Region." This ensures your data is stored in a specific geographic location, offering lower latency for services within the same region.
+    *   **Location:** Choose the **same region where your Jira application (e.g., running on Cloud Run) and your Cloud SQL instance are deployed.** This is critical for performance and to minimize cross-region data transfer costs.
+5.  **Choose a default storage class for your data:**
+    *   Select "Standard" storage. This is recommended for frequently accessed data like Jira attachments.
+6.  **Choose how to control access to objects:**
+    *   Select "Uniform" for "Access control." This ensures consistent permissions across all objects in the bucket, managed by IAM.
+7.  **Optional: Protect object data (Data protection):**
+    *   You can consider enabling features like "Object versioning" to keep previous versions of attachments or "Retention policy" if you have specific data lifecycle requirements. For a standard Jira setup, these are often not immediately necessary but can be configured based on your organization's policies.
+8.  **Create:** Click "Create." Confirm any choices if prompted.
+
+## 4. Configuring IAM Permissions
+
+For your Jira application (assumed to be running on Cloud Run) to read from and write to this bucket, its service account needs appropriate permissions.
+
+1.  **Identify your Cloud Run Service Account:**
+    *   If your Jira application is deployed on Cloud Run:
+        *   Navigate to your Jira service in the Cloud Run section of the Google Cloud Console.
+        *   Go to the "Security" or "Identity" tab (the exact name might vary slightly).
+        *   You will find the **service account email** listed there. It typically looks like `PROJECT_NUMBER-compute@developer.gserviceaccount.com` (default Compute Engine service account) or a custom service account if you configured one (e.g., `your-jira-service-account@your-project-id.iam.gserviceaccount.com`).
+    *   If you are using a different service for Jira (e.g., GKE), identify the service account used by your Jira pods/nodes.
+
+2.  **Grant Permissions to the Service Account:**
+    *   Navigate back to "Cloud Storage" > "Buckets" in the Google Cloud Console.
+    *   Click on the name of the bucket you just created.
+    *   Go to the **"Permissions"** tab.
+    *   Under "View by Principals," click the **"Grant Access"** button.
+    *   In the "New principals" field, paste the service account email you identified in the previous step.
+    *   In the "Assign roles" dropdown, select the role **"Storage Object Admin"** (its identifier is `roles/storage.objectAdmin`). This role provides full control over objects within the bucket (create, read, update, delete).
+    *   Click **"Save."**
+
+    This ensures that your Jira application has the necessary rights to manage attachments in the bucket.
+
+## 5. Required Information for Jira Configuration
+
+After setting up the GCS bucket and configuring its permissions, you will need the following information for your Jira application's environment configuration:
+
+*   **`GCS_BUCKET_NAME`**: This is the **globally unique name** you assigned to your GCS bucket in Step 3 (e.g., `your-company-jira-attachments`).
+
+Your Jira application's custom entrypoint script (`custom_entrypoint.sh`) will use this environment variable to know where to synchronize attachments. Ensure this variable is correctly set in the environment where your Jira application is running.

--- a/startup_scripts/custom_entrypoint.sh
+++ b/startup_scripts/custom_entrypoint.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+echo "Custom entrypoint script is running."
+
+# Check for required environment variables
+REQUIRED_VARS=("DB_HOST" "DB_NAME" "DB_USER" "DB_PASSWORD" "GCS_BUCKET_NAME")
+for VAR_NAME in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!VAR_NAME}" ]; then
+    echo "Error: Environment variable ${VAR_NAME} is not set." >&2
+    exit 1
+  fi
+done
+
+JIRA_HOME="/var/atlassian/application-data/jira"
+DB_PORT_EFFECTIVE="${DB_PORT:-3306}"
+
+# Create dbconfig.xml if database variables are set
+if [ -n "$DB_HOST" ] && [ -n "$DB_NAME" ] && [ -n "$DB_USER" ] && [ -n "$DB_PASSWORD" ]; then
+  echo "Configuring Jira database connection (dbconfig.xml)..."
+  mkdir -p "$JIRA_HOME"
+  cat <<EOF > "$JIRA_HOME/dbconfig.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<jira-database-config>
+  <name>defaultDS</name>
+  <delegator-name>default</delegator-name>
+  <database-type>mysql8</database-type>
+  <schema-name>public</schema-name>
+  <jdbc-datasource>
+    <url>jdbc:mysql://${DB_HOST}:${DB_PORT_EFFECTIVE}/${DB_NAME}?sessionVariables=sql_mode=NO_AUTO_VALUE_ON_ZERO&amp;autoReconnect=true&amp;useSSL=false</url>
+    <driver-class>com.mysql.cj.jdbc.Driver</driver-class>
+    <username>${DB_USER}</username>
+    <password>${DB_PASSWORD}</password>
+    <pool-min-size>20</pool-min-size>
+    <pool-max-size>20</pool-max-size>
+    <pool-max-wait>30000</pool-max-wait>
+    <pool-max-idle>20</pool-max-idle>
+    <pool-remove-abandoned>true</pool-remove-abandoned>
+    <pool-remove-abandoned-timeout>300</pool-remove-abandoned-timeout>
+    <validation-query>SELECT 1</validation-query>
+    <validation-query-timeout>3</validation-query-timeout>
+    <time-between-eviction-runs-millis>30000</time-between-eviction-runs-millis>
+    <min-evictable-idle-time-millis>60000</min-evictable-idle-time-millis>
+    <test-on-borrow>false</test-on-borrow>
+    <test-while-idle>true</test-while-idle>
+    <connection-properties>tcpKeepAlive=true;socketTimeout=240</connection-properties>
+  </jdbc-datasource>
+</jira-database-config>
+EOF
+  echo "Setting ownership of dbconfig.xml to jira user..."
+  chown 2001:2001 "$JIRA_HOME/dbconfig.xml"
+  echo "dbconfig.xml configured."
+else
+  echo "Skipping dbconfig.xml creation as not all database variables are set."
+fi
+
+JIRA_ATTACHMENTS_DIR="$JIRA_HOME/data/attachments"
+mkdir -p "$JIRA_ATTACHMENTS_DIR"
+
+if [ -n "$GCS_BUCKET_NAME" ]; then
+  echo "Synchronizing attachments from GCS bucket: gs://${GCS_BUCKET_NAME}/attachments to ${JIRA_ATTACHMENTS_DIR}..."
+  # Ensure gsutil is available and configured if needed (gcloud auth might be required if not using workload identity)
+  if command -v gsutil &> /dev/null; then
+    gsutil -m rsync -r "gs://${GCS_BUCKET_NAME}/attachments" "$JIRA_ATTACHMENTS_DIR"
+    echo "Attachment synchronization complete."
+    echo "Setting ownership of attachments directory to jira user..."
+    chown -R 2001:2001 "$JIRA_ATTACHMENTS_DIR"
+    echo "Attachment directory ownership set."
+  else
+    echo "Warning: gsutil command not found. Skipping GCS attachment synchronization." >&2
+  fi
+else
+    echo "GCS_BUCKET_NAME not set. Skipping attachment synchronization."
+fi
+
+# Remove Jira lock file
+if [ -f "$JIRA_HOME/.jira-home.lock" ]; then
+  echo "Removing existing Jira lock file: $JIRA_HOME/.jira-home.lock"
+  rm -f "$JIRA_HOME/.jira-home.lock"
+fi
+
+echo "Handing over to original Jira entrypoint (/entrypoint.sh)..."
+exec /entrypoint.sh "$@"


### PR DESCRIPTION
This commit modifies the existing Jira on Cloud Run setup to use MySQL as the database backend instead of PostgreSQL.

Changes include:
- Dockerfile updated to install the MySQL client (`default-mysql-client`).
- The `custom_entrypoint.sh` script now generates a `dbconfig.xml` file tailored for MySQL, including the correct database type, JDBC driver, and URL formation (with `sql_mode` considerations).
- `CLOUD_SQL_SETUP.md` has been rewritten to guide you through setting up a Cloud SQL for MySQL instance, with appropriate SQL commands for database and user creation (using `utf8mb4_bin` collation).
- `CLOUD_RUN_DEPLOYMENT.md` and `README.md` have been updated to consistently refer to MySQL and provide relevant examples (e.g., default MySQL port).

The GCS setup for attachments remains unchanged as it is database-agnostic. This provides you with the flexibility to choose MySQL for your Jira deployment on Cloud Run.